### PR TITLE
Feature/cehck write permissions in protected directories

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nativescript-root-detection",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "NativeScript plugin to detect root on Android and JailBreak on iOS",
     "main": "root-detection",
     "typings": "index.d.ts",

--- a/src/root-detection.ios.ts
+++ b/src/root-detection.ios.ts
@@ -1,5 +1,5 @@
 import {Common} from './root-detection.common';
-import {File} from 'tns-core-modules/file-system';
+import {File, Folder} from 'tns-core-modules/file-system';
 
 const knownLocations = [
     "/Applications/Cydia.app",
@@ -35,7 +35,35 @@ export class RootDetection extends Common {
                 rooted = true;
             }
         });
+        if (!rooted) {
+            return this.canWriteToSystemDirectories();
+        }
         return rooted;
+    }
+
+    private static canWriteToSystemDirectories(): boolean {
+        let stringToWrite = "Jailbreak Test";
+        let privateDir = "/private/";
+        let applicationDir = "/Applications";
+        if (Folder.exists(privateDir)) {
+            let path = "/private/jailbreak.txt";
+            let systemDir = File.fromPath(path);
+
+            systemDir.writeText(stringToWrite).then(result => {
+                return true;
+            }).catch(err => {
+            });
+        }
+        if (Folder.exists(applicationDir)) {
+            let path = "/Applications/jailbreak.txt";
+            let dir = File.fromPath(path);
+
+            dir.writeText(stringToWrite).then(result => {
+                return true;
+            }).catch(err => {
+            });
+        }
+        return false;
     }
 
 }


### PR DESCRIPTION
## What is the current behavior?
Jailbroken device check currently checks if certain apps and files are installed on the device. If those apps or files are there but are in a different location than expected, the conclusion would be a false negative.

## What is the new behavior?
In addition to the above checks, we also need to check whether one can write to protected dirs like the `/private` or `/Applications` dirs. If so, then the device is jailbroken
